### PR TITLE
Add comprehensive tests for PDFMergerController and LocalStorageService

### DIFF
--- a/src/test/java/org/alexismp/pdfmerger/LocalStorageServiceTests.java
+++ b/src/test/java/org/alexismp/pdfmerger/LocalStorageServiceTests.java
@@ -1,0 +1,334 @@
+package org.alexismp.pdfmerger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Files;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import java.util.List;
+
+// Imports for this test method
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
+
+class LocalStorageServiceTests {
+
+    private LocalStorageService storageService;
+
+    @TempDir
+    Path tempDir; // JUnit 5 will inject a temporary directory here
+
+    @BeforeEach
+    void setUp() throws IOException {
+        // LocalStorageService was modified in the previous step to accept Path in its constructor.
+        // The constructor itself does not call init(), so we call it here.
+        storageService = new LocalStorageService(tempDir);
+        storageService.init(); // Call init to create the directory structure within tempDir
+    }
+
+    // Test methods will be added in subsequent steps.
+    @Test
+    void testInit_CreatesDirectory() {
+        // storageService.init() is called in @BeforeEach setUp()
+
+        // Get the root directory from the service (getter was added in a previous step)
+        Path rootDir = storageService.getRootLocation();
+
+        // Assert that the directory specified by storageService.getRootLocation() exists
+        assertTrue(Files.exists(rootDir), "Root directory should exist after init.");
+        assertTrue(Files.isDirectory(rootDir), "Root path should be a directory after init.");
+
+        // Also, test that calling init() multiple times is safe (idempotent)
+        assertDoesNotThrow(() -> storageService.init(), "Calling init() multiple times should not throw an exception.");
+        assertTrue(Files.exists(rootDir), "Root directory should still exist after calling init() again.");
+    }
+
+    @Test
+    void testStorePDF_ValidFile() throws IOException {
+        String idPrefix = "testPrefix_validFile";
+        MockMultipartFile mockFile = new MockMultipartFile(
+                "file", // Parameter name in a multipart request
+                "test.pdf", // Original filename
+                MediaType.APPLICATION_PDF_VALUE, // Content type
+                "test pdf content".getBytes() // File content
+        );
+
+        // Action: Call storePDF and assert it doesn't throw an exception for a valid file
+        assertDoesNotThrow(() -> storageService.storePDF(mockFile, idPrefix),
+                "storePDF should not throw an exception for a valid file.");
+
+        // Assertions for directory creation
+        Path expectedDir = storageService.getRootLocation().resolve(idPrefix);
+        assertTrue(Files.exists(expectedDir), "Directory for idPrefix should be created within rootLocation.");
+        assertTrue(Files.isDirectory(expectedDir), "Path for idPrefix should be a directory.");
+
+        // Assertions for file storage
+        Path expectedPath = expectedDir.resolve("test.pdf");
+        assertTrue(Files.exists(expectedPath), "Stored PDF file should exist at the expected path.");
+        assertArrayEquals("test pdf content".getBytes(), Files.readAllBytes(expectedPath),
+                "Content of stored PDF file should match the input content.");
+
+        // Assertions for the internal state (allFiles map via getFilesToMerge)
+        List<Path> filesToMerge = storageService.getFilesToMerge(idPrefix);
+        assertNotNull(filesToMerge, "List of files to merge should not be null after storing a file.");
+        assertEquals(1, filesToMerge.size(), "There should be one file in the list to merge.");
+        // Compare absolute paths to avoid issues with relative vs. absolute path differences
+        assertEquals(expectedPath.toAbsolutePath(), filesToMerge.get(0).toAbsolutePath(),
+                "The path of the stored file should be correctly recorded in the filesToMerge list.");
+    }
+
+    @Test
+    void testStorePDF_NonPdfFile_ThrowsException() {
+        String idPrefix = "testPrefix_nonPdfFile";
+        MockMultipartFile mockNonPdfFile = new MockMultipartFile(
+                "file",
+                "test.txt", // Non-PDF extension
+                MediaType.TEXT_PLAIN_VALUE,
+                "some text content".getBytes()
+        );
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            storageService.storePDF(mockNonPdfFile, idPrefix);
+        }, "storePDF should throw ResponseStatusException for non-PDF files.");
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus(),
+                "Exception status should be BAD_REQUEST for non-PDF files.");
+
+        // Based on current LocalStorageService.storePDF logic:
+        // 1. The user-specific directory IS created before the file type check.
+        // 2. The entry in `allFiles` map IS created before the file type check.
+        // So, we adjust assertions from the example.
+
+        Path expectedDir = storageService.getRootLocation().resolve(idPrefix);
+        assertTrue(Files.exists(expectedDir),
+                "Directory for idPrefix SHOULD be created even if file is invalid, as per current logic.");
+        assertTrue(Files.isDirectory(expectedDir));
+
+        // Assert that the actual file "test.txt" was not created within that directory.
+        Path actualFile = expectedDir.resolve("test.txt");
+        assertFalse(Files.exists(actualFile),
+                "The non-PDF file itself should not be stored in the directory.");
+
+        // Verify the allFiles map was populated but the file was not added to the list.
+        List<Path> filesToMerge = storageService.getFilesToMerge(idPrefix);
+        assertNotNull(filesToMerge, "Files to merge list should not be null, as map entry is created before file type check.");
+        assertTrue(filesToMerge.isEmpty(), "Files to merge list should be empty as the invalid file was not added.");
+    }
+
+    @Test
+    void testStorePDF_EmptyFile_ThrowsException() {
+        String idPrefix = "testPrefix_emptyFile";
+        MockMultipartFile mockEmptyFile = new MockMultipartFile(
+                "file",
+                "empty.pdf", // Valid PDF name
+                MediaType.APPLICATION_PDF_VALUE,
+                new byte[0]  // Empty content
+        );
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            storageService.storePDF(mockEmptyFile, idPrefix);
+        }, "storePDF should throw ResponseStatusException for empty files.");
+
+        assertEquals(HttpStatus.NO_CONTENT, exception.getStatus(),
+                "Exception status should be NO_CONTENT for empty files.");
+
+        // Based on current LocalStorageService.storePDF logic:
+        // 1. The user-specific directory IS created before the file emptiness check.
+        // 2. The entry in `allFiles` map IS created before the file emptiness check.
+        // So, we adjust assertions similar to the non-PDF file test.
+
+        Path expectedDir = storageService.getRootLocation().resolve(idPrefix);
+        assertTrue(Files.exists(expectedDir),
+                "Directory for idPrefix SHOULD be created even if file is empty, as per current logic.");
+        assertTrue(Files.isDirectory(expectedDir));
+
+        // Assert that the actual file "empty.pdf" was not created within that directory.
+        Path actualFile = expectedDir.resolve("empty.pdf");
+        assertFalse(Files.exists(actualFile),
+                "The empty file itself should not be stored in the directory.");
+
+        // Verify the allFiles map was populated but the file was not added to the list.
+        List<Path> filesToMerge = storageService.getFilesToMerge(idPrefix);
+        assertNotNull(filesToMerge, "Files to merge list should not be null, as map entry is created before file emptiness check.");
+        assertTrue(filesToMerge.isEmpty(), "Files to merge list should be empty as the empty file was not added.");
+    }
+
+    @Test
+    void testStorePDF_PathTraversalAttempt_ThrowsException() {
+        String idPrefix = "testPrefix_pathTraversal";
+        MockMultipartFile mockTraversalFile = new MockMultipartFile(
+                "file",
+                "../secret.pdf", // Path traversal attempt
+                MediaType.APPLICATION_PDF_VALUE,
+                "malicious content".getBytes()
+        );
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            storageService.storePDF(mockTraversalFile, idPrefix);
+        }, "storePDF should throw ResponseStatusException for path traversal attempt.");
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatus(),
+                "Exception status should be FORBIDDEN for path traversal attempt.");
+
+        // Directory for idPrefix IS created before filename validation
+        Path expectedDir = storageService.getRootLocation().resolve(idPrefix);
+        assertTrue(Files.exists(expectedDir),
+                "Directory for idPrefix SHOULD be created even if filename is malicious, as per current logic.");
+        assertTrue(Files.isDirectory(expectedDir));
+
+        // Assert that the file was NOT created by attempting to traverse up.
+        // The path userSpecificDir.resolve("../secret.pdf") would normalize to getRootLocation().resolve("secret.pdf")
+        Path attemptedStorePath = storageService.getRootLocation().resolve("secret.pdf").normalize();
+        assertFalse(Files.exists(attemptedStorePath),
+                "File should NOT be created at the normalized path after attempting traversal.");
+
+        // Also, ensure no file was created within the idPrefix directory itself (e.g. if '..' was stripped, which it isn't)
+        assertFalse(Files.exists(expectedDir.resolve("secret.pdf")),
+                "File should not be created inside the idPrefix directory with a sanitized name.");
+        // And ensure the original problematic name wasn't used directly within the idPrefix directory
+        // (though resolve would handle this, this is an extra check for clarity on what's NOT happening)
+        assertFalse(Files.exists(expectedDir.resolve(mockTraversalFile.getOriginalFilename())),
+                "File should not be created using the raw original filename containing '..' inside idPrefix dir.");
+
+
+        // Verify the allFiles map was populated but the file was not added to the list.
+        List<Path> filesToMerge = storageService.getFilesToMerge(idPrefix);
+        assertNotNull(filesToMerge, "Files to merge list should not be null, as map entry is created before filename validation.");
+        assertTrue(filesToMerge.isEmpty(), "Files to merge list should be empty as the path traversal attempt prevented storage.");
+    }
+
+    @Test
+    void testNumberOfFilesToMerge_NoFilesForPrefix() {
+        String idPrefix = "prefixWithNoFiles";
+        // Attempt to store a non-PDF file. This will throw an exception,
+        // but LocalStorageService.storePDF initializes the list for this idPrefix in allFiles before the check.
+        MockMultipartFile mockNonPdfFile = new MockMultipartFile(
+                "file",
+                "test.txt",
+                MediaType.TEXT_PLAIN_VALUE,
+                "text content".getBytes()
+        );
+        assertThrows(ResponseStatusException.class, () -> storageService.storePDF(mockNonPdfFile, idPrefix));
+
+        assertEquals(0, storageService.numberOfFilesToMerge(idPrefix),
+                "Should be 0 files if storePDF failed to add any valid PDF for the prefix.");
+    }
+
+    @Test
+    void testNumberOfFilesToMerge_FilesStored() throws IOException {
+        String idPrefix = "prefixWithTwoFiles";
+        MockMultipartFile file1 = new MockMultipartFile(
+                "file1", // Different parameter names just for clarity, not strictly necessary
+                "f1.pdf",
+                MediaType.APPLICATION_PDF_VALUE,
+                "pdf content 1".getBytes()
+        );
+        MockMultipartFile file2 = new MockMultipartFile(
+                "file2",
+                "f2.pdf",
+                MediaType.APPLICATION_PDF_VALUE,
+                "pdf content 2".getBytes()
+        );
+
+        // Store the files successfully
+        assertDoesNotThrow(() -> storageService.storePDF(file1, idPrefix));
+        assertDoesNotThrow(() -> storageService.storePDF(file2, idPrefix));
+
+        assertEquals(2, storageService.numberOfFilesToMerge(idPrefix),
+                "Should return the correct count of successfully stored files.");
+    }
+
+    @Test
+    void testNumberOfFilesToMerge_NonExistentPrefix() {
+        String idPrefix = "completelyNewPrefix";
+        // This prefix was never used with storePDF, so it's not in allFiles map.
+        // The numberOfFilesToMerge method should handle this gracefully.
+        assertEquals(0, storageService.numberOfFilesToMerge(idPrefix),
+                "Should be 0 files for a prefix that was never processed by storePDF.");
+    }
+
+    @Test
+    void testGetMergedPDF_FileExists_ReadsAndDeletes() throws IOException {
+        String idPrefix = "prefixForGetMergedPdfSuccess";
+        // outputFilename is "output.pdf" in LocalStorageService, which is used to form the merged file name
+        Path mergedPdfPath = storageService.getRootLocation().resolve(idPrefix + "-" + "output.pdf");
+        byte[] expectedContent = "dummy merged PDF content".getBytes();
+
+        // Manually create the expected merged file
+        // Parent directory (rootLocation) should already exist due to init() in setUp()
+        Files.write(mergedPdfPath, expectedContent);
+        assertTrue(Files.exists(mergedPdfPath), "Dummy merged PDF should exist before calling getMergedPDF.");
+
+        byte[] actualContent = storageService.getMergedPDF(idPrefix);
+
+        assertArrayEquals(expectedContent, actualContent, "Returned content should match dummy file content.");
+        assertFalse(Files.exists(mergedPdfPath), "Merged PDF file should be deleted after getMergedPDF is called.");
+    }
+
+    @Test
+    void testGetMergedPDF_FileDoesNotExist_ThrowsException() {
+        String idPrefix = "prefixForGetMergedPdfFail";
+        // Ensure no file exists at storageService.getRootLocation().resolve(idPrefix + "-" + "output.pdf")
+        // This is implicitly true for a new, unused idPrefix.
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            storageService.getMergedPDF(idPrefix);
+        }, "getMergedPDF should throw ResponseStatusException if merged file doesn't exist.");
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatus(),
+                "Exception status should be FORBIDDEN if merged file doesn't exist.");
+    }
+
+    @Test
+    void testMergeFiles_PerformsCleanup() throws IOException {
+        String idPrefix = "prefixForMergeFilesCleanup";
+        Path individualFilesDir = storageService.getRootLocation().resolve(idPrefix);
+        // Assuming outputFilename in LocalStorageService is "output.pdf"
+        Path mergedOutputFile = storageService.getRootLocation().resolve(idPrefix + "-" + "output.pdf");
+
+        // 1. Store some dummy files
+        MockMultipartFile file1 = new MockMultipartFile(
+                "f", // request parameter name
+                "f1.pdf", // original filename
+                MediaType.APPLICATION_PDF_VALUE,
+                "c1".getBytes() // content
+        );
+        assertDoesNotThrow(() -> storageService.storePDF(file1, idPrefix));
+        assertTrue(Files.exists(individualFilesDir.resolve("f1.pdf")), "Dummy file1 should exist before mergeFiles.");
+        assertNotNull(storageService.getFilesToMerge(idPrefix), "allFiles map should have entry before mergeFiles.");
+
+        // 2. Create a dummy merged output file (as if pdfunite created it)
+        // This ensures mergeFiles's finally block doesn't delete what getMergedPDF expects.
+        Files.write(mergedOutputFile, "dummy output from pdfunite".getBytes());
+        assertTrue(Files.exists(mergedOutputFile), "Dummy merged output file should exist before mergeFiles.");
+
+        // 3. Call mergeFiles. It might throw ResponseStatusException if pdfunite fails or is missing.
+        // We are interested in the cleanup performed in its 'finally' block.
+        try {
+            storageService.mergeFiles(idPrefix);
+        } catch (ResponseStatusException e) {
+            // Log or print if needed, but allow test to continue to check cleanup.
+            System.out.println("mergeFiles threw ResponseStatusException (expected if pdfunite is missing/fails): " + e.getMessage());
+        }
+
+        // 4. Assert cleanup of individual files and directory
+        // The LocalStorageService.mergeFiles() method, in its finally block, deletes individual files
+        // and then the directory.
+        assertFalse(Files.exists(individualFilesDir),
+                "Directory for individual files (" + idPrefix + ") should be deleted after mergeFiles.");
+
+        // 5. Assert idPrefix is removed from allFiles map
+        assertNull(storageService.getFilesToMerge(idPrefix),
+                "Entry for idPrefix should be removed from allFiles map after mergeFiles.");
+
+        // 6. Assert that the main merged output file was NOT deleted by mergeFiles's cleanup
+        assertTrue(Files.exists(mergedOutputFile),
+                "The main merged output file should NOT be deleted by mergeFiles's cleanup.");
+    }
+}

--- a/src/test/java/org/alexismp/pdfmerger/PDFMergerControllerTests.java
+++ b/src/test/java/org/alexismp/pdfmerger/PDFMergerControllerTests.java
@@ -1,0 +1,189 @@
+package org.alexismp.pdfmerger;
+
+import org.alexismp.pdfmerger.storage.StorageService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus; // Added import
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException; // Added import
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+// No need for MockMvcBuilders.standaloneSetup when using @SpringBootTest and @AutoConfigureMockMvc
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class PDFMergerControllerTests {
+
+    @Autowired
+    private MockMvc mvc; // Changed from mockMvc to mvc to match existing variable name
+
+    @MockBean
+    private StorageService storageService;
+
+    @Test
+    public void testHandleFileUpload_NoFiles() throws Exception {
+        // When no files are uploaded, numberOfFilesToMerge should be 0
+        // The controller generates a prefix and calls numberOfFilesToMerge with it.
+        when(storageService.numberOfFilesToMerge(anyString())).thenReturn(0);
+
+        mvc.perform(multipart("/pdfmerger")) // Using existing 'mvc' field
+                .andExpect(status().isOk())
+                .andExpect(content().string(""));
+
+        // Verify that storageService.numberOfFilesToMerge was called once
+        verify(storageService, times(1)).numberOfFilesToMerge(anyString());
+        // Verify other storageService methods were not called
+        verify(storageService, never()).storePDF(any(), anyString());
+        verify(storageService, never()).mergeFiles(anyString());
+        verify(storageService, never()).getMergedPDF(anyString());
+    }
+    // Test methods will be added here in future steps
+
+    @Test
+    public void testHandleFileUpload_OneFile() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "files", // Name of the request parameter
+                "file1.pdf",
+                MediaType.APPLICATION_PDF_VALUE,
+                "pdf_content_for_file1".getBytes()
+        );
+
+        byte[] mergedPdfContent = "merged_pdf_content".getBytes();
+
+        // Mocking StorageService behavior
+        // storePDF is void, so doNothing is appropriate if we just want to ensure it's called
+        doNothing().when(storageService).storePDF(any(MultipartFile.class), anyString());
+        when(storageService.numberOfFilesToMerge(anyString())).thenReturn(1);
+        doNothing().when(storageService).mergeFiles(anyString());
+        when(storageService.getMergedPDF(anyString())).thenReturn(mergedPdfContent);
+
+        mvc.perform(multipart("/pdfmerger").file(file))
+                .andExpect(status().isOk())
+                .andExpect(content().bytes(mergedPdfContent));
+
+        // Verify interactions with storageService
+        // The controller generates a UUID prefix, so we use anyString() for that argument.
+        verify(storageService, times(1)).storePDF(eq(file), anyString());
+        verify(storageService, times(1)).numberOfFilesToMerge(anyString());
+        verify(storageService, times(1)).mergeFiles(anyString());
+        verify(storageService, times(1)).getMergedPDF(anyString());
+    }
+
+    @Test
+    public void testHandleFileUpload_MultipleFiles() throws Exception {
+        MockMultipartFile file1 = new MockMultipartFile(
+                "files",
+                "file1.pdf",
+                MediaType.APPLICATION_PDF_VALUE,
+                "pdf_content_file1".getBytes()
+        );
+        MockMultipartFile file2 = new MockMultipartFile(
+                "files",
+                "file2.pdf",
+                MediaType.APPLICATION_PDF_VALUE,
+                "pdf_content_file2".getBytes()
+        );
+
+        byte[] mergedPdfContent = "merged_pdf_content_multiple".getBytes();
+
+        // Mocking StorageService behavior
+        doNothing().when(storageService).storePDF(any(MultipartFile.class), anyString());
+        when(storageService.numberOfFilesToMerge(anyString())).thenReturn(2); // For two files
+        doNothing().when(storageService).mergeFiles(anyString());
+        when(storageService.getMergedPDF(anyString())).thenReturn(mergedPdfContent);
+
+        mvc.perform(multipart("/pdfmerger").file(file1).file(file2))
+                .andExpect(status().isOk())
+                .andExpect(content().bytes(mergedPdfContent));
+
+        // Verify interactions with storageService
+        // The controller generates a UUID prefix, so we use anyString() for that argument.
+        // storePDF is called for each file with the same prefix.
+        verify(storageService, times(1)).storePDF(eq(file1), anyString());
+        verify(storageService, times(1)).storePDF(eq(file2), anyString());
+        verify(storageService, times(1)).numberOfFilesToMerge(anyString()); // Called once after all files are stored
+        verify(storageService, times(1)).mergeFiles(anyString());
+        verify(storageService, times(1)).getMergedPDF(anyString());
+    }
+
+    @Test
+    public void testHandleFileUpload_NonPdfFile() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "files",
+                "file1.txt", // Non-PDF extension
+                MediaType.TEXT_PLAIN_VALUE, // Appropriate content type
+                "some_text_content".getBytes()
+        );
+
+        // Mocking StorageService behavior
+        // Configure storePDF to throw ResponseStatusException for non-PDFs
+        doThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, "Only PDF files are allowed"))
+            .when(storageService).storePDF(eq(file), anyString());
+
+        mvc.perform(multipart("/pdfmerger").file(file))
+                .andExpect(status().isBadRequest()); // Expecting a 400 Bad Request
+
+        // Verify interactions with storageService
+        verify(storageService, times(1)).storePDF(eq(file), anyString());
+        verify(storageService, never()).numberOfFilesToMerge(anyString());
+        verify(storageService, never()).mergeFiles(anyString());
+        verify(storageService, never()).getMergedPDF(anyString());
+    }
+
+    @Test
+    public void testHandleFileUpload_EmptyOriginalFilename() throws Exception {
+        MockMultipartFile fileWithEmptyName = new MockMultipartFile(
+                "files", // Name of the request parameter
+                "",      // Empty original filename
+                MediaType.APPLICATION_PDF_VALUE,
+                "pdf_content".getBytes() // Content can be non-empty for this test
+        );
+
+        // Mocking StorageService behavior
+        // storePDF should not be called.
+        // numberOfFilesToMerge will be called, and since storePDF wasn't, it should reflect 0 files to merge.
+        when(storageService.numberOfFilesToMerge(anyString())).thenReturn(0);
+
+        mvc.perform(multipart("/pdfmerger").file(fileWithEmptyName))
+                .andExpect(status().isOk())
+                .andExpect(content().string(""));
+
+        // Verify interactions with storageService
+        verify(storageService, never()).storePDF(any(MultipartFile.class), anyString());
+        verify(storageService, times(1)).numberOfFilesToMerge(anyString());
+        verify(storageService, never()).mergeFiles(anyString());
+        verify(storageService, never()).getMergedPDF(anyString());
+    }
+
+    @Test
+    public void testHandleFileUpload_EmptyFileContent() throws Exception {
+        MockMultipartFile emptyFile = new MockMultipartFile(
+                "files",
+                "empty_file.pdf", // Non-empty original filename
+                MediaType.APPLICATION_PDF_VALUE,
+                new byte[0]       // Empty content
+        );
+
+        // Mocking StorageService behavior
+        // storePDF will be called, and it should throw an exception for an empty file.
+        doThrow(new ResponseStatusException(HttpStatus.NO_CONTENT, "File is empty"))
+            .when(storageService).storePDF(eq(emptyFile), anyString());
+
+        mvc.perform(multipart("/pdfmerger").file(emptyFile))
+                .andExpect(status().isNoContent()); // Expecting a 204 No Content
+
+        // Verify interactions with storageService
+        verify(storageService, times(1)).storePDF(eq(emptyFile), anyString());
+        verify(storageService, never()).numberOfFilesToMerge(anyString());
+        verify(storageService, never()).mergeFiles(anyString());
+        verify(storageService, never()).getMergedPDF(anyString());
+    }
+}


### PR DESCRIPTION
This commit introduces a suite of JUnit 5 tests for the main controller and file storage service of the PDF merger application.

Key changes include:

1.  **PDFMergerControllerTests:**
    *   Mocks StorageService to ensure focused controller testing.
    *   Covers various file upload scenarios:
        *   No files, single file, multiple files.
        *   Invalid file types (e.g., .txt).
        *   Files with empty original filenames (ignored by controller).
        *   Files with empty content (handled by StorageService).
    *   Verifies correct HTTP responses and interactions with the StorageService mock.

2.  **LocalStorageService Refactoring for Testability:**
    *   Modified LocalStorageService to accept a root Path in its constructor, enabling the use of JUnit's @TempDir for cleaner tests.
    *   Added `getRootLocation()` and `getFilesToMerge(String idPrefix)` getters to aid in test assertions.

3.  **LocalStorageServiceTests:**
    *   Uses @TempDir for isolated file system operations during tests.
    *   `init()`: Verifies directory creation and idempotency.
    *   `storePDF()`: Tests successful storage, handling of non-PDF files (BAD_REQUEST), empty files (NO_CONTENT), and path traversal attempts in filenames (FORBIDDEN). Verifies file system changes and internal map updates.
    *   `numberOfFilesToMerge()`: Checks correct counts for various states.
    *   `getMergedPDF()`: Tests reading/deletion of the merged PDF and error handling for missing files (FORBIDDEN).
    *   `mergeFiles()`: Focuses on testing the cleanup logic (deletion of temporary individual files and removal from internal map) which occurs in a `finally` block. This test is structured to run assertions even if the external `pdfunite` command fails or is unavailable.

These tests significantly improve the code coverage and provide confidence in the existing functionality.