### PR TITLE
Implement dynamic output filenames and update tests

### DIFF
--- a/src/main/java/org/alexismp/pdfmerger/MergedPdfFile.java
+++ b/src/main/java/org/alexismp/pdfmerger/MergedPdfFile.java
@@ -1,0 +1,3 @@
+package org.alexismp.pdfmerger;
+
+public record MergedPdfFile(byte[] content, String filename) {}

--- a/src/main/java/org/alexismp/pdfmerger/StorageService.java
+++ b/src/main/java/org/alexismp/pdfmerger/StorageService.java
@@ -21,7 +21,7 @@ import org.springframework.web.multipart.MultipartFile;
 public interface StorageService {
 	void init();
 	void storePDF(MultipartFile file, String idPrefix);
-	byte[] getMergedPDF(String idPrefix);
+	MergedPdfFile getMergedPDF(String idPrefix); // Changed return type
 	void mergeFiles(String idPrefix);
 	int numberOfFilesToMerge(String idPrefix);
 }


### PR DESCRIPTION
This commit introduces dynamic filename generation for merged PDFs based on input file names and updates the controller to use these names in the Content-Disposition header.

Key changes:

1.  **Dynamic Filename Generation (`LocalStorageService`):**
    *   Merged PDFs are now named based on their input files (e.g., "file1_and_file2_merged.pdf").
    *   A new internal map `generatedFilenamesByPrefix` stores the generated name part associated with a processing `idPrefix`.
    *   The actual file path on disk includes the `idPrefix` for disambiguation (e.g., `idPrefix-file1_and_file2_merged.pdf`), while the user-facing filename is cleaner.

2.  **`StorageService` Interface Update:**
    *   Introduced `MergedPdfFile(byte[] content, String filename)` record.
    *   `getMergedPDF` method in `StorageService` and `LocalStorageService` now returns `MergedPdfFile` to provide both content and the dynamic filename.
    *   `LocalStorageService.getMergedPDF` now also cleans up the entry from `generatedFilenamesByPrefix`.

3.  **`PDFMergerController` Update:**
    *   `handleFileUpload` now returns `ResponseEntity<byte[]>`.
    *   Sets the `Content-Disposition: attachment; filename="<dynamic_name.pdf>"` HTTP header, using the filename from the `MergedPdfFile` object.
    *   Returns `HttpStatus.NO_CONTENT` if no files are processed.

4.  **Test Updates:**
    *   `LocalStorageServiceTests`:
        *   Added helper methods to `LocalStorageService` (`setGeneratedFilenameForPrefix`, `getGeneratedFilenameForPrefix`) to facilitate testing of the dynamic filename logic.
        *   Updated tests for `getMergedPDF` and `mergeFiles` to reflect the new return types, filename storage, and cleanup logic.
    *   `PDFMergerControllerTests`:
        *   Updated tests to mock `storageService.getMergedPDF` returning `MergedPdfFile`.
        *   Assertions for successful merges now verify the `Content-Disposition` header and filename.
        *   Tests for scenarios resulting in no merged file (e.g., no files uploaded) now expect `HttpStatus.NO_CONTENT`.

This enhancement provides you with more descriptively named downloaded files.